### PR TITLE
Prevent overriding higher priority roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "scheddy",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/src/routes/callback/+page.server.ts
+++ b/src/routes/callback/+page.server.ts
@@ -148,8 +148,13 @@ export const load: PageServerLoad = async ({ cookies, url, fetch }) => {
 			if (role.role == 'WM') {
 				highest_role = ROLE_DEVELOPER;
 			} else if (role.role == 'ATM' || role.role == 'DATM' || role.role == 'TA') {
+			} else if (
+				(role.role == 'ATM' || role.role == 'DATM' || role.role == 'TA') &&
+				ROLE_STAFF > highest_role
+			) {
 				highest_role = ROLE_STAFF;
 			} else if (role.role == 'INS' || role.role == 'MTR') {
+			} else if ((role.role == 'INS' || role.role == 'MTR') && ROLE_MENTOR > highest_role) {
 				highest_role = ROLE_MENTOR;
 			}
 		}


### PR DESCRIPTION
This PR will:
- Prevent high priority roles (such as WM) to be overwritten with lower level roles (such as TA).
- Close #26 