### PR TITLE
Implement session types ordering

### DIFF
--- a/drizzle/0002_session-types-ordering.sql
+++ b/drizzle/0002_session-types-ordering.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sessionType` ADD `order` int NOT NULL DEFAULT 0;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,477 @@
+{
+	"version": "5",
+	"dialect": "mysql",
+	"id": "a1b0de96-90c9-4d20-8b50-d1f8116031e5",
+	"prevId": "e004ae6a-877f-4092-a4bc-aab91adf3a65",
+	"tables": {
+		"mentor": {
+			"name": "mentor",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"firstName": {
+					"name": "firstName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"roleOverride": {
+					"name": "roleOverride",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"isVisitor": {
+					"name": "isVisitor",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rating": {
+					"name": "rating",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mentorAvailability": {
+					"name": "mentorAvailability",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedSessionTypes": {
+					"name": "allowedSessionTypes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"timezone": {
+					"name": "timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"mentor_id": {
+					"name": "mentor_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"sessionType": {
+			"name": "sessionType",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(21)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"category": {
+					"name": "category",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"length": {
+					"name": "length",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"order": {
+					"name": "order",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"sessionType_id": {
+					"name": "sessionType_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(26)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mentor": {
+					"name": "mentor",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"student": {
+					"name": "student",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(21)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"start": {
+					"name": "start",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"reminded": {
+					"name": "reminded",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"timezone": {
+					"name": "timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"session_mentor_user_id_fk": {
+					"name": "session_mentor_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["mentor"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"session_student_user_id_fk": {
+					"name": "session_student_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["student"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"session_type_sessionType_id_fk": {
+					"name": "session_type_sessionType_id_fk",
+					"tableFrom": "session",
+					"tableTo": "sessionType",
+					"columnsFrom": ["type"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"session_id": {
+					"name": "session_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"student": {
+			"name": "student",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"firstName": {
+					"name": "firstName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"roleOverride": {
+					"name": "roleOverride",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"isVisitor": {
+					"name": "isVisitor",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rating": {
+					"name": "rating",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mentorAvailability": {
+					"name": "mentorAvailability",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedSessionTypes": {
+					"name": "allowedSessionTypes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"timezone": {
+					"name": "timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"student_id": {
+					"name": "student_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"userToken": {
+			"name": "userToken",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(21)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user": {
+					"name": "user",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"userToken_user_user_id_fk": {
+					"name": "userToken_user_user_id_fk",
+					"tableFrom": "userToken",
+					"tableTo": "user",
+					"columnsFrom": ["user"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"userToken_id": {
+					"name": "userToken_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"firstName": {
+					"name": "firstName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastName": {
+					"name": "lastName",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"roleOverride": {
+					"name": "roleOverride",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"isVisitor": {
+					"name": "isVisitor",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rating": {
+					"name": "rating",
+					"type": "int",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"mentorAvailability": {
+					"name": "mentorAvailability",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"allowedSessionTypes": {
+					"name": "allowedSessionTypes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"timezone": {
+					"name": "timezone",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"user_id": {
+					"name": "user_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {}
+	}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
 			"when": 1732417717687,
 			"tag": "0001_sessions-ulids",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "5",
+			"when": 1737672345418,
+			"tag": "0002_session-types-ordering",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -26,7 +26,8 @@ export const sessionTypes = mysqlTable('sessionType', {
 	id: varchar({ length: 21 }).primaryKey().notNull(),
 	name: text().notNull(),
 	category: text().notNull(),
-	length: int().notNull()
+	length: int().notNull(),
+	order: int().notNull().default(0)
 });
 
 export const sessions = mysqlTable('session', {

--- a/src/routes/(authed)/dash/types/+page.server.ts
+++ b/src/routes/(authed)/dash/types/+page.server.ts
@@ -40,7 +40,8 @@ export const actions: Actions = {
 			id: nanoid(),
 			name: form.data.name,
 			length: form.data.duration,
-			category: form.data.category
+			category: form.data.category,
+			order: form.data.order
 		});
 
 		return { createForm: form };

--- a/src/routes/(authed)/dash/types/CreateForm.svelte
+++ b/src/routes/(authed)/dash/types/CreateForm.svelte
@@ -46,6 +46,14 @@
 			name="category"
 			error={$errors.category}
 		/>
+		<Input
+			label="Order"
+			{...$constraints.order}
+			bind:value={$form.order}
+			name="order"
+			type="number"
+			error={$errors.order}
+		/>
 	</div>
 
 	<ModalFooter>

--- a/src/routes/(authed)/dash/types/createSchema.ts
+++ b/src/routes/(authed)/dash/types/createSchema.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const createSchema = z.object({
 	name: z.string(),
 	duration: z.number(),
-	category: z.string()
+	category: z.string(),
+	order: z.number()
 });
 export type CreateSchema = typeof createSchema;

--- a/src/routes/(authed)/schedule/+page.svelte
+++ b/src/routes/(authed)/schedule/+page.svelte
@@ -25,13 +25,14 @@
 	}
 
 	let categories = $derived.by(() => {
-		let c = {};
-		for (let t of data.sessionTypes) {
+		const c = new Map(); // using `Map` to respect the insert order
+		const sessionsOrdered = [...data.sessionTypes].sort((a, b) => a.order - b.order);
+		for (const t of sessionsOrdered) {
 			if (t && t.category) {
-				if (!Object.keys(c).includes(t.category)) {
-					c[t.category] = [];
+				if (![...c.keys()].includes(t.category)) {
+					c.set(t.category, []);
 				}
-				c[t.category].push(t);
+				c.set(t.category, [...c.get(t.category), t]);
 			}
 		}
 		return c;
@@ -154,7 +155,7 @@
 					</p>
 				{:else if step === 1}
 					<Select bind:value={sessionType} label="Session Type">
-						{#each Object.entries(categories) as [k, v]}
+						{#each categories.entries() as [k, v]}
 							<optgroup label={k}>
 								{#each v as typ}
 									<option value={typ.id}>{typ.name} ({typ.length} minutes)</option>


### PR DESCRIPTION
Fixes #11

## Description

Adds a new field, `order`, to the `sessionType` table so that sessions can be ordered in the scheduling page `select`. No UI is made available for _changing_ this field afterward, as no UI is currently present for editing anything about session types. If need be, editing this field via the DB is fairly simple.

## Screenshots

**Create form**
![image](https://github.com/user-attachments/assets/0b2b6c6b-fcd2-4f77-ae76-66218f3029ab)

**Order in the the dashboard**
![image](https://github.com/user-attachments/assets/52f91a8f-e773-4627-a4c8-3703155823a7)

**Order in the DB**
![image](https://github.com/user-attachments/assets/295d7daa-95d1-4dad-a422-b694f4d693d0)

**Order in the UI**
![image](https://github.com/user-attachments/assets/01ab45f8-c28e-4497-b65e-18ccdcad3cb0)
