### PR TITLE
Implement optional student pending session limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ VATUSA_API_KEY=""
 
 # Maximum # of days after today that users will be able to book
 MAX_BOOKING_AHEAD_DAYS=14
+# Maximum # of pending sessions
+MAX_PENDING_SESSIONS=2
 
 # SMTP Email Information
 SMTP_HOST=""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       VATUSA_API_BASE: ${{ vars.VATUSA_API_BASE }}
       VATUSA_API_KEY: ${{ secrets.VATUSA_API_KEY }}
       MAX_BOOKING_AHEAD_DAYS: ${{ vars.MAX_BOOKING_AHEAD_DAYS }}
+      MAX_PENDING_SESSIONS: ${{ vars.MAX_PENDING_SESSIONS }}
       SMTP_HOST: ${{ secrets.SMTP_HOST }}
       SMTP_PORT: ${{ secrets.SMTP_PORT }}
       SMTP_SECURE: ${{ secrets.SMTP_SECURE }}

--- a/src/routes/(authed)/schedule/+page.server.ts
+++ b/src/routes/(authed)/schedule/+page.server.ts
@@ -205,6 +205,7 @@ export const load: PageServerLoad = async ({ cookies, url }) => {
 	const allSessions = await db.select().from(sessions);
 
 	let slotData;
+	let atMaxSessions;
 	// count the pending sessions for the student
 	const now = DateTime.utc();
 	const pendingForStudent = allSessions.filter(
@@ -214,8 +215,10 @@ export const load: PageServerLoad = async ({ cookies, url }) => {
 	if (maxPending > 0 && pendingForStudent >= maxPending) {
 		// don't allow the student to book any more sessions
 		slotData = {};
+		atMaxSessions = true;
 	} else {
 		slotData = slottificate(sTypes, mentors, allSessions);
+		atMaxSessions = false;
 	}
 
 	const originalSessionType = url.searchParams.has('reschedule')
@@ -235,7 +238,8 @@ export const load: PageServerLoad = async ({ cookies, url }) => {
 		slotData,
 		originalSessionType,
 		originalSessionId,
-		ogSession
+		ogSession,
+		atMaxSessions
 	};
 };
 

--- a/src/routes/(authed)/schedule/+page.svelte
+++ b/src/routes/(authed)/schedule/+page.svelte
@@ -191,7 +191,11 @@
 										.length} minutes</option
 								>
 							{:else}
-								<option disabled>No slots available :( Check back another time</option>
+								{#if data.atMaxSessions}
+									<option disabled>You already have the max number of sessions booked</option>
+								{:else}
+									<option disabled>No slots available :( Check back another time</option>
+								{/if}
 							{/each}
 						</Select>
 					{/if}


### PR DESCRIPTION
Fixes #29

## Description

Adds a new field to the configuration file that, if set, allows the site administrator to control how many sessions a student is allowed to book at once. This _adds to_ the existing limit of how far in advance they can book. This would automate a currently manual check that ZDV does.

If the student already has the number of pending sessions that's set, they'll still see the session types dropdown, but won't see any available session dates. I'm open to a different approach.

![image](https://github.com/user-attachments/assets/9fd67c10-2dd1-4036-8d77-d95397db7b9f)
