### PR TITLE
Migrate lucide to SV5 version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       },
       "devDependencies": {
         "@internationalized/date": "^3.7.0",
+        "@lucide/svelte": "^0.488.0",
         "@sveltejs/adapter-node": "^5.2.12",
         "@sveltejs/kit": "^2.18.0",
         "@sveltejs/vite-plugin-svelte": "^4.0.4",
@@ -31,7 +32,6 @@
         "formsnap": "^2.0.0",
         "globals": "^15.15.0",
         "ical": "^0.8.0",
-        "lucide-svelte": "^0.476.0",
         "luxon": "^3.5.0",
         "mode-watcher": "^0.5.1",
         "mysql2": "^3.13.0",
@@ -205,6 +205,8 @@
     "@libsql/core": ["@libsql/core@0.14.0", "", { "dependencies": { "js-base64": "^3.7.5" } }, "sha512-nhbuXf7GP3PSZgdCY2Ecj8vz187ptHlZQ0VRc751oB2C1W8jQUXKKklvt7t1LJiUTQBVJuadF628eUk+3cRi4Q=="],
 
     "@libsql/libsql-wasm-experimental": ["@libsql/libsql-wasm-experimental@0.0.2", "", { "bin": { "sqlite-wasm": "bin/index.js" } }, "sha512-xkiu88QwozGr3KEt9h0zeHLYUIWkeDchXmuOUW4/Wh/mRZkDlNtIIePAR0FiLl1j0o4OyTEOtPnvmaXQ5MNTKQ=="],
+
+    "@lucide/svelte": ["@lucide/svelte@0.488.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-i8TFY+vOVci2J/UhaeF1Yj25NOL8UJ27hf+/CexvfIyLSdgid3zHwh0iVf+DlWpAsXXJl2rQ5Cl5g/qfMbfOHw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -789,8 +791,6 @@
     "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "lru.min": ["lru.min@1.1.1", "", {}, "sha512-FbAj6lXil6t8z4z3j0E5mfRlPzxkySotzUHwRXjlpRh10vc6AI6WN62ehZj82VG7M20rqogJ0GLwar2Xa05a8Q=="],
-
-    "lucide-svelte": ["lucide-svelte@0.476.0", "", { "peerDependencies": { "svelte": "^3 || ^4 || ^5.0.0-next.42" } }, "sha512-Ph6zoMWjQVJibDrR+DJoT7LR2uEKLPzzGo886OLRk+nCJZESJUvoCWXk0uE6Y9aaamaSFAdI1Cpwslgzk3YYdQ=="],
 
     "luxon": ["luxon@3.5.0", "", {}, "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	},
 	"devDependencies": {
 		"@internationalized/date": "^3.7.0",
+		"@lucide/svelte": "^0.488.0",
 		"@sveltejs/adapter-node": "^5.2.12",
 		"@sveltejs/kit": "^2.18.0",
 		"@sveltejs/vite-plugin-svelte": "^4.0.4",
@@ -40,7 +41,6 @@
 		"formsnap": "^2.0.0",
 		"globals": "^15.15.0",
 		"ical": "^0.8.0",
-		"lucide-svelte": "^0.476.0",
 		"luxon": "^3.5.0",
 		"mode-watcher": "^0.5.1",
 		"mysql2": "^3.13.0",

--- a/src/lib/components/ui/accordion/accordion-trigger.svelte
+++ b/src/lib/components/ui/accordion/accordion-trigger.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Accordion as AccordionPrimitive, type WithoutChild } from 'bits-ui';
-	import ChevronDown from 'lucide-svelte/icons/chevron-down';
+	import ChevronDown from '@lucide/svelte/icons/chevron-down';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/breadcrumb/breadcrumb-ellipsis.svelte
+++ b/src/lib/components/ui/breadcrumb/breadcrumb-ellipsis.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Ellipsis from 'lucide-svelte/icons/ellipsis';
+	import Ellipsis from '@lucide/svelte/icons/ellipsis';
 	import type { WithElementRef, WithoutChildren } from 'bits-ui';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { cn } from '$lib/utils.js';

--- a/src/lib/components/ui/breadcrumb/breadcrumb-separator.svelte
+++ b/src/lib/components/ui/breadcrumb/breadcrumb-separator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import type { WithElementRef } from 'bits-ui';
 	import type { HTMLLiAttributes } from 'svelte/elements';
 	import { cn } from '$lib/utils.js';

--- a/src/lib/components/ui/calendar/calendar-next-button.svelte
+++ b/src/lib/components/ui/calendar/calendar-next-button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Calendar as CalendarPrimitive } from 'bits-ui';
-	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import { buttonVariants } from '$lib/components/ui/button/index.js';
 	import { cn } from '$lib/utils.js';
 

--- a/src/lib/components/ui/calendar/calendar-prev-button.svelte
+++ b/src/lib/components/ui/calendar/calendar-prev-button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Calendar as CalendarPrimitive } from 'bits-ui';
-	import ChevronLeft from 'lucide-svelte/icons/chevron-left';
+	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
 	import { buttonVariants } from '$lib/components/ui/button/index.js';
 	import { cn } from '$lib/utils.js';
 

--- a/src/lib/components/ui/carousel/carousel-next.svelte
+++ b/src/lib/components/ui/carousel/carousel-next.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import ArrowRight from 'lucide-svelte/icons/arrow-right';
+	import ArrowRight from '@lucide/svelte/icons/arrow-right';
 	import type { WithoutChildren } from 'bits-ui';
 	import { getEmblaContext } from './context.js';
 	import { cn } from '$lib/utils.js';

--- a/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Checkbox as CheckboxPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
-	import Check from 'lucide-svelte/icons/check';
-	import Minus from 'lucide-svelte/icons/minus';
+	import Check from '@lucide/svelte/icons/check';
+	import Minus from '@lucide/svelte/icons/minus';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/command/command-input.svelte
+++ b/src/lib/components/ui/command/command-input.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Command as CommandPrimitive } from 'bits-ui';
-	import Search from 'lucide-svelte/icons/search';
+	import Search from '@lucide/svelte/icons/search';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/context-menu/context-menu-checkbox-item.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-checkbox-item.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { ContextMenu as ContextMenuPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
-	import Check from 'lucide-svelte/icons/check';
-	import Minus from 'lucide-svelte/icons/minus';
+	import Check from '@lucide/svelte/icons/check';
+	import Minus from '@lucide/svelte/icons/minus';
 	import { cn } from '$lib/utils.js';
 	import type { Snippet } from 'svelte';
 

--- a/src/lib/components/ui/context-menu/context-menu-radio-item.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-radio-item.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ContextMenu as ContextMenuPrimitive, type WithoutChild } from 'bits-ui';
-	import Circle from 'lucide-svelte/icons/circle';
+	import Circle from '@lucide/svelte/icons/circle';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/context-menu/context-menu-sub-trigger.svelte
+++ b/src/lib/components/ui/context-menu/context-menu-sub-trigger.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ContextMenu as ContextMenuPrimitive, type WithoutChild } from 'bits-ui';
-	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Dialog as DialogPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
-	import X from 'lucide-svelte/icons/x';
+	import X from '@lucide/svelte/icons/x';
 	import type { Snippet } from 'svelte';
 	import * as Dialog from './index.js';
 	import { cn } from '$lib/utils.js';

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { DropdownMenu as DropdownMenuPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
-	import Check from 'lucide-svelte/icons/check';
-	import Minus from 'lucide-svelte/icons/minus';
+	import Check from '@lucide/svelte/icons/check';
+	import Minus from '@lucide/svelte/icons/minus';
 	import { cn } from '$lib/utils.js';
 	import type { Snippet } from 'svelte';
 

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { DropdownMenu as DropdownMenuPrimitive, type WithoutChild } from 'bits-ui';
-	import Circle from 'lucide-svelte/icons/circle';
+	import Circle from '@lucide/svelte/icons/circle';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-sub-trigger.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-sub-trigger.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
-	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/input-otp/input-otp-separator.svelte
+++ b/src/lib/components/ui/input-otp/input-otp-separator.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { HTMLAttributes } from 'svelte/elements';
 	import type { WithElementRef } from 'bits-ui';
-	import Dot from 'lucide-svelte/icons/dot';
+	import Dot from '@lucide/svelte/icons/dot';
 
 	let {
 		ref = $bindable(null),

--- a/src/lib/components/ui/menubar/menubar-checkbox-item.svelte
+++ b/src/lib/components/ui/menubar/menubar-checkbox-item.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Menubar as MenubarPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
-	import Check from 'lucide-svelte/icons/check';
-	import Minus from 'lucide-svelte/icons/minus';
+	import Check from '@lucide/svelte/icons/check';
+	import Minus from '@lucide/svelte/icons/minus';
 	import { cn } from '$lib/utils.js';
 	import type { Snippet } from 'svelte';
 

--- a/src/lib/components/ui/menubar/menubar-radio-item.svelte
+++ b/src/lib/components/ui/menubar/menubar-radio-item.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Menubar as MenubarPrimitive, type WithoutChild } from 'bits-ui';
-	import Circle from 'lucide-svelte/icons/circle';
+	import Circle from '@lucide/svelte/icons/circle';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/menubar/menubar-sub-trigger.svelte
+++ b/src/lib/components/ui/menubar/menubar-sub-trigger.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Menubar as MenubarPrimitive, type WithoutChild } from 'bits-ui';
-	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/pagination/pagination-ellipsis.svelte
+++ b/src/lib/components/ui/pagination/pagination-ellipsis.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Ellipsis from 'lucide-svelte/icons/ellipsis';
+	import Ellipsis from '@lucide/svelte/icons/ellipsis';
 	import type { WithElementRef, WithoutChildren } from 'bits-ui';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { cn } from '$lib/utils.js';

--- a/src/lib/components/ui/pagination/pagination-next-button.svelte
+++ b/src/lib/components/ui/pagination/pagination-next-button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Pagination as PaginationPrimitive } from 'bits-ui';
-	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+	import ChevronRight from '@lucide/svelte/icons/chevron-right';
 	import { buttonVariants } from '$lib/components/ui/button/index.js';
 	import { cn } from '$lib/utils.js';
 

--- a/src/lib/components/ui/pagination/pagination-prev-button.svelte
+++ b/src/lib/components/ui/pagination/pagination-prev-button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Pagination as PaginationPrimitive } from 'bits-ui';
-	import ChevronLeft from 'lucide-svelte/icons/chevron-left';
+	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
 	import { buttonVariants } from '$lib/components/ui/button/index.js';
 	import { cn } from '$lib/utils.js';
 

--- a/src/lib/components/ui/resizable/resizable-handle.svelte
+++ b/src/lib/components/ui/resizable/resizable-handle.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import GripVertical from 'lucide-svelte/icons/grip-vertical';
+	import GripVertical from '@lucide/svelte/icons/grip-vertical';
 	import * as ResizablePrimitive from 'paneforge';
 	import type { WithoutChildrenOrChild } from 'bits-ui';
 	import { cn } from '$lib/utils.js';

--- a/src/lib/components/ui/select/select-item.svelte
+++ b/src/lib/components/ui/select/select-item.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Check from 'lucide-svelte/icons/check';
+	import Check from '@lucide/svelte/icons/check';
 	import { Select as SelectPrimitive, type WithoutChild } from 'bits-ui';
 	import { cn } from '$lib/utils.js';
 

--- a/src/lib/components/ui/select/select-scroll-down-button.svelte
+++ b/src/lib/components/ui/select/select-scroll-down-button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import ChevronDown from 'lucide-svelte/icons/chevron-down';
+	import ChevronDown from '@lucide/svelte/icons/chevron-down';
 	import { Select as SelectPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
 	import { cn } from '$lib/utils.js';
 

--- a/src/lib/components/ui/select/select-scroll-up-button.svelte
+++ b/src/lib/components/ui/select/select-scroll-up-button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import ChevronUp from 'lucide-svelte/icons/chevron-up';
+	import ChevronUp from '@lucide/svelte/icons/chevron-up';
 	import { Select as SelectPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
 	import { cn } from '$lib/utils.js';
 

--- a/src/lib/components/ui/select/select-trigger.svelte
+++ b/src/lib/components/ui/select/select-trigger.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Select as SelectPrimitive, type WithoutChild } from 'bits-ui';
-	import ChevronDown from 'lucide-svelte/icons/chevron-down';
+	import ChevronDown from '@lucide/svelte/icons/chevron-down';
 	import { cn } from '$lib/utils.js';
 
 	let {

--- a/src/lib/components/ui/sidebar/sidebar-trigger.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-trigger.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { cn } from '$lib/utils.js';
-	import PanelLeft from 'lucide-svelte/icons/panel-left';
+	import PanelLeft from '@lucide/svelte/icons/panel-left';
 	import type { ComponentProps } from 'svelte';
 	import { useSidebar } from './context.svelte.js';
 

--- a/src/lib/ui/UserSelector.svelte
+++ b/src/lib/ui/UserSelector.svelte
@@ -5,7 +5,7 @@
 	import * as Form from '$lib/components/ui/form';
 	import { buttonVariants } from '$lib/components/ui/button';
 	import { ChevronsUpDown } from 'lucide-svelte';
-	import Check from 'lucide-svelte/icons/check';
+	import Check from '@lucide/svelte/icons/check';
 	import { cn } from '$lib/utils';
 	import { computeCommandScore, useId } from 'bits-ui';
 

--- a/src/routes/(authed)/dash/+page.svelte
+++ b/src/routes/(authed)/dash/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import * as Card from '$lib/components/ui/card';
-	import { ArrowUpDown, CalendarCheck2, TowerControlIcon } from 'lucide-svelte';
+	import ArrowUpDown from '@lucide/svelte/icons/arrow-up-down';
+	import CalendarCheck2 from '@lucide/svelte/icons/calendar-check-2';
+	import TowerControlIcon from '@lucide/svelte/icons/tower-control';
 
 	interface Props {
 		data: PageData;

--- a/src/routes/(authed)/dash/MainNav.svelte
+++ b/src/routes/(authed)/dash/MainNav.svelte
@@ -1,17 +1,15 @@
 <script lang="ts">
-	import {
-		ArrowUpDown,
-		CalendarClockIcon,
-		CalendarIcon,
-		CalendarPlusIcon,
-		GraduationCapIcon,
-		HistoryIcon,
-		Layers2Icon,
-		LayoutGridIcon,
-		LibraryIcon,
-		UsersIcon,
-		X
-	} from 'lucide-svelte';
+	import ArrowUpDown from '@lucide/svelte/icons/arrow-up-down';
+	import CalendarClockIcon from '@lucide/svelte/icons/calendar-clock';
+	import CalendarIcon from '@lucide/svelte/icons/calendar';
+	import CalendarPlusIcon from '@lucide/svelte/icons/calendar-plus';
+	import GraduationCapIcon from '@lucide/svelte/icons/graduation-cap';
+	import HistoryIcon from '@lucide/svelte/icons/history';
+	import LayoutGridIcon from '@lucide/svelte/icons/layout-grid';
+	import LibraryIcon from '@lucide/svelte/icons/library';
+	import Layers2Icon from '@lucide/svelte/icons/layers-2';
+	import UsersIcon from '@lucide/svelte/icons/users';
+	import X from '@lucide/svelte/icons/x';
 	import { ROLE_MENTOR, ROLE_STAFF, ROLE_STUDENT } from '$lib/utils';
 	import type { NestedMenuItem } from './nav';
 	import NavSection from './NavSection.svelte';

--- a/src/routes/(authed)/dash/NavItem.svelte
+++ b/src/routes/(authed)/dash/NavItem.svelte
@@ -2,7 +2,7 @@
 	import type { NestedMenuItem } from './nav';
 	import * as Collapsible from '$lib/components/ui/collapsible';
 	import * as Sidebar from '$lib/components/ui/sidebar';
-	import { ChevronRightIcon } from 'lucide-svelte';
+	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	// yes, this imports itself
 	import NavItem from './NavItem.svelte';
 	import { page } from '$app/state';

--- a/src/routes/(authed)/dash/NavUser.svelte
+++ b/src/routes/(authed)/dash/NavUser.svelte
@@ -2,14 +2,12 @@
 	import { useSidebar } from '$lib/components/ui/sidebar';
 	import * as Sidebar from '$lib/components/ui/sidebar';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
-	import {
-		ChevronsUpDown,
-		LogOutIcon,
-		MoonIcon,
-		SunIcon,
-		SunMoonIcon,
-		UserIcon
-	} from 'lucide-svelte';
+	import ChevronsUpDown from '@lucide/svelte/icons/chevrons-up-down';
+	import SunIcon from '@lucide/svelte/icons/sun';
+	import MoonIcon from '@lucide/svelte/icons/moon';
+	import SunMoonIcon from '@lucide/svelte/icons/sun-moon';
+	import UserIcon from '@lucide/svelte/icons/user';
+	import LogOutIcon from '@lucide/svelte/icons/log-out';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { setMode, systemPrefersMode } from 'mode-watcher';
 

--- a/src/routes/(authed)/dash/SbFacility.svelte
+++ b/src/routes/(authed)/dash/SbFacility.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Sidebar from '$lib/components/ui/sidebar';
 	import { version } from '$app/environment';
-	import { TowerControl } from 'lucide-svelte';
+	import TowerControl from '@lucide/svelte/icons/tower-control';
 	import { clientConfig } from '$lib/config/client';
 </script>
 

--- a/src/routes/(authed)/dash/mentors/DataTableActions.svelte
+++ b/src/routes/(authed)/dash/mentors/DataTableActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Ellipsis from 'lucide-svelte/icons/ellipsis';
+	import Ellipsis from '@lucide/svelte/icons/ellipsis';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 	import { toast } from 'svelte-sonner';

--- a/src/routes/(authed)/dash/mentors/[userId]/DataTableActions.svelte
+++ b/src/routes/(authed)/dash/mentors/[userId]/DataTableActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Ellipsis from 'lucide-svelte/icons/ellipsis';
+	import Ellipsis from '@lucide/svelte/icons/ellipsis';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 	import { roleOf } from '$lib';

--- a/src/routes/(authed)/dash/mentors/[userId]/DataTableDateButton.svelte
+++ b/src/routes/(authed)/dash/mentors/[userId]/DataTableDateButton.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import type { ComponentProps } from 'svelte';
-	import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-svelte';
+	import ArrowDown from '@lucide/svelte/icons/arrow-down';
+	import ArrowUp from '@lucide/svelte/icons/arrow-up';
+	import ArrowUpDown from '@lucide/svelte/icons/arrow-up-down';
+
 	import { Button } from '$lib/components/ui/button';
 
 	let {

--- a/src/routes/(authed)/dash/mentors/[userId]/availability/SpecificDateAvailability.svelte
+++ b/src/routes/(authed)/dash/mentors/[userId]/availability/SpecificDateAvailability.svelte
@@ -5,7 +5,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Popover from '$lib/components/ui/popover';
 	import { cn } from '$lib/utils';
-	import { CalendarIcon } from 'lucide-svelte';
+	import CalendarIcon from '@lucide/svelte/icons/calendar';
 	import { Calendar } from '$lib/components/ui/calendar';
 	import SpecificDateAvailabilityControl from './SpecificDateAvailabilityControl.svelte';
 

--- a/src/routes/(authed)/dash/mentors/[userId]/availability/SpecificDateAvailabilityControl.svelte
+++ b/src/routes/(authed)/dash/mentors/[userId]/availability/SpecificDateAvailabilityControl.svelte
@@ -6,7 +6,6 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Separator } from '$lib/components/ui/separator';
 	import { Button } from '$lib/components/ui/button';
-	import { TrashIcon } from 'lucide-svelte';
 
 	interface Props {
 		dayId: string;

--- a/src/routes/(authed)/dash/mentors/[userId]/types/allowed_types/+page.svelte
+++ b/src/routes/(authed)/dash/mentors/[userId]/types/allowed_types/+page.svelte
@@ -5,7 +5,7 @@
 	import * as Form from '$lib/components/ui/form';
 	import { toast } from 'svelte-sonner';
 	import { Switch } from '$lib/components/ui/switch';
-	import { LoaderCircleIcon } from 'lucide-svelte';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 
 	interface Props {
 		data: PageData;

--- a/src/routes/(authed)/dash/mentors/[userId]/types/bookable_types/+page.svelte
+++ b/src/routes/(authed)/dash/mentors/[userId]/types/bookable_types/+page.svelte
@@ -5,7 +5,7 @@
 	import * as Form from '$lib/components/ui/form';
 	import { toast } from 'svelte-sonner';
 	import { Switch } from '$lib/components/ui/switch';
-	import { LoaderCircleIcon } from 'lucide-svelte';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 
 	interface Props {
 		data: PageData;

--- a/src/routes/(authed)/dash/sessions/[sessionId]/+page.svelte
+++ b/src/routes/(authed)/dash/sessions/[sessionId]/+page.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { DateTime } from 'luxon';
-	import {
-		CalendarDaysIcon,
-		ClockIcon,
-		GraduationCapIcon,
-		IdCardIcon,
-		PencilIcon,
-		X
-	} from 'lucide-svelte';
+	import CalendarDaysIcon from '@lucide/svelte/icons/calendar-days';
+	import ClockIcon from '@lucide/svelte/icons/clock';
+	import GraduationCapIcon from '@lucide/svelte/icons/graduation-cap';
+	import IdCardIcon from '@lucide/svelte/icons/id-card';
+	import PencilIcon from '@lucide/svelte/icons/pencil';
+	import X from '@lucide/svelte/icons/x';
 	import { Button } from '$lib/components/ui/button';
 	import DataDisplay from './DataDisplay.svelte';
 	import { roleOf } from '$lib';

--- a/src/routes/(authed)/dash/sessions/[sessionId]/DataDisplay.svelte
+++ b/src/routes/(authed)/dash/sessions/[sessionId]/DataDisplay.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import type { Snippet } from 'svelte';
+	import type { Component, Snippet } from 'svelte';
 
 	interface Props {
-		icon: never;
+		icon: Component;
 		label: string;
 		children: Snippet;
 	}

--- a/src/routes/(authed)/dash/sessions/[sessionId]/edit/+page.svelte
+++ b/src/routes/(authed)/dash/sessions/[sessionId]/edit/+page.svelte
@@ -2,7 +2,8 @@
 	import type { PageData } from './$types';
 	import { DateTime } from 'luxon';
 	import { goto } from '$app/navigation';
-	import { CalendarIcon, LoaderCircleIcon } from 'lucide-svelte';
+	import CalendarIcon from '@lucide/svelte/icons/calendar';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import { buttonVariants } from '$lib/components/ui/button';
 	import { toast } from 'svelte-sonner';
 	import { superForm } from 'sveltekit-superforms';

--- a/src/routes/(authed)/dash/sessions/[sessionId]/transfer/+page.svelte
+++ b/src/routes/(authed)/dash/sessions/[sessionId]/transfer/+page.svelte
@@ -5,7 +5,7 @@
 	import { toast } from 'svelte-sonner';
 	import * as Form from '$lib/components/ui/form';
 	import UserSelector from '$lib/ui/UserSelector.svelte';
-	import { LoaderCircleIcon } from 'lucide-svelte';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 
 	interface Props {
 		data: PageData;

--- a/src/routes/(authed)/dash/sessions/create/+page.svelte
+++ b/src/routes/(authed)/dash/sessions/create/+page.svelte
@@ -2,7 +2,8 @@
 	import type { PageData } from './$types';
 	import { DateTime, Interval } from 'luxon';
 	import { goto } from '$app/navigation';
-	import { CalendarIcon, LoaderCircleIcon } from 'lucide-svelte';
+	import CalendarIcon from '@lucide/svelte/icons/calendar';
+	import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 	import { buttonVariants } from '$lib/components/ui/button';
 	import { toast } from 'svelte-sonner';
 	import { superForm } from 'sveltekit-superforms';

--- a/src/routes/(authed)/dash/types/DataTableActions.svelte
+++ b/src/routes/(authed)/dash/types/DataTableActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Ellipsis from 'lucide-svelte/icons/ellipsis';
+	import Ellipsis from '@lucide/svelte/icons/ellipsis';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 	import { toast } from 'svelte-sonner';

--- a/src/routes/(authed)/dash/types/DataTableAddButton.svelte
+++ b/src/routes/(authed)/dash/types/DataTableAddButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { PlusIcon } from 'lucide-svelte';
+	import PlusIcon from '@lucide/svelte/icons/plus';
 </script>
 
 <Button class="float-right" size="sm" href="/dash/types/add">

--- a/src/routes/(authed)/dash/types/add/+page.svelte
+++ b/src/routes/(authed)/dash/types/add/+page.svelte
@@ -5,7 +5,7 @@
 	import { toast } from 'svelte-sonner';
 	import * as Form from '$lib/components/ui/form';
 	import { Input } from '$lib/components/ui/input';
-	import { LoaderCircle } from 'lucide-svelte';
+	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import { ratingIdDisplay, RATINGS } from '$lib/utils';
 	import * as Select from '$lib/components/ui/select';
 	import { Checkbox } from '$lib/components/ui/checkbox';

--- a/src/routes/(authed)/dash/types/delete/[typeId]/+page.svelte
+++ b/src/routes/(authed)/dash/types/delete/[typeId]/+page.svelte
@@ -4,8 +4,7 @@
 	import { superForm } from 'sveltekit-superforms';
 	import { toast } from 'svelte-sonner';
 	import * as Form from '$lib/components/ui/form';
-
-	import { LoaderCircle } from 'lucide-svelte';
+	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import { Button } from '$lib/components/ui/button';
 
 	interface Props {

--- a/src/routes/(authed)/dash/types/edit/[typeId]/+page.svelte
+++ b/src/routes/(authed)/dash/types/edit/[typeId]/+page.svelte
@@ -6,7 +6,7 @@
 	import * as Form from '$lib/components/ui/form';
 	import * as Select from '$lib/components/ui/select';
 	import { Input } from '$lib/components/ui/input';
-	import { LoaderCircle } from 'lucide-svelte';
+	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import { ratingIdDisplay, RATINGS } from '$lib/utils';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 

--- a/src/routes/(authed)/dash/users/DataTableActions.svelte
+++ b/src/routes/(authed)/dash/users/DataTableActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Ellipsis from 'lucide-svelte/icons/ellipsis';
+	import Ellipsis from '@lucide/svelte/icons/ellipsis';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 	import { toast } from 'svelte-sonner';

--- a/src/routes/(authed)/dash/users/DataTableAddButton.svelte
+++ b/src/routes/(authed)/dash/users/DataTableAddButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
-	import { PlusIcon } from 'lucide-svelte';
+	import PlusIcon from '@lucide/svelte/icons/plus';
 </script>
 
 <Button class="float-right" size="sm" href="/dash/users/set">

--- a/src/routes/(authed)/dash/users/set/+page.svelte
+++ b/src/routes/(authed)/dash/users/set/+page.svelte
@@ -5,7 +5,7 @@
 	import * as Form from '$lib/components/ui/form';
 	import * as Select from '$lib/components/ui/select';
 	import { ROLE_DEVELOPER, ROLE_MENTOR, ROLE_STAFF, ROLE_STUDENT, roleString } from '$lib/utils.js';
-	import { LoaderCircleIcon } from 'lucide-svelte';
+	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import { goto } from '$app/navigation';
 	import { toast } from 'svelte-sonner';
 

--- a/src/routes/(authed)/my_sessions/DataTableActions.svelte
+++ b/src/routes/(authed)/my_sessions/DataTableActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Ellipsis from 'lucide-svelte/icons/ellipsis';
+	import Ellipsis from '@lucide/svelte/icons/ellipsis';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 	import { roleOf } from '$lib';

--- a/src/routes/(authed)/my_sessions/DataTableDateButton.svelte
+++ b/src/routes/(authed)/my_sessions/DataTableDateButton.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { ComponentProps } from 'svelte';
-	import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-svelte';
+	import ArrowDown from '@lucide/svelte/icons/arrow-down';
+	import ArrowUp from '@lucide/svelte/icons/arrow-up';
+	import ArrowUpDown from '@lucide/svelte/icons/arrow-up-down';
 	import { Button } from '$lib/components/ui/button';
 
 	let {

--- a/src/routes/(authed)/schedule/+page.svelte
+++ b/src/routes/(authed)/schedule/+page.svelte
@@ -4,7 +4,8 @@
 	import * as Form from '$lib/components/ui/form';
 	import * as Select from '$lib/components/ui/select';
 	import { version } from '$app/environment';
-	import { HeartIcon, LoaderCircle } from 'lucide-svelte';
+	import HeartIcon from '@lucide/svelte/icons/heart';
+	import LoaderCircle from '@lucide/svelte/icons/loader-circle';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { superForm } from 'sveltekit-superforms';
 	import { DateTime, Interval } from 'luxon';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { version } from '$app/environment';
-	import { HeartIcon } from 'lucide-svelte';
+	import HeartIcon from '@lucide/svelte/icons/heart';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { clientConfig } from '$lib/config/client';


### PR DESCRIPTION
Migrates from ```lucide-svelte``` to ```@lucide/svelte``` and fixes some type errors that came with using the SV4 version