### PR TITLE
Apply fallback config entries to the parsed config

### DIFF
--- a/src/lib/config/schema.ts
+++ b/src/lib/config/schema.ts
@@ -97,6 +97,7 @@ export function recursiveOverlayConfig(config: any, current_key: string, env: an
 						`Invalid overlay configuration in ${env_var}: expected ${typeof config[key]} found ${typeof value}`
 					);
 				}
+				copy[key] = value;
 			}
 		}
 	}


### PR DESCRIPTION
This fallback condition exists in the config generation, but nothing was being applied to the `copy` variable, like in the case of SCHEDDY_SMTP_SECURE, which is a boolean.