### PR TITLE
Don't send reminder emails for cancelled sessions

### DIFF
--- a/src/routes/api/sendReminderEmails/+server.ts
+++ b/src/routes/api/sendReminderEmails/+server.ts
@@ -1,6 +1,6 @@
 import { db } from '$lib/server/db';
 import { sessions, sessionTypes, students, mentors } from '$lib/server/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import { sendEmail } from '$lib/email';
 import { reminder } from '$lib/emails/student/reminder';
@@ -13,7 +13,7 @@ export async function GET() {
 		.leftJoin(mentors, eq(mentors.id, sessions.mentor))
 		.leftJoin(students, eq(students.id, sessions.student))
 		.leftJoin(sessionTypes, eq(sessionTypes.id, sessions.type))
-		.where(eq(sessions.reminded, false));
+		.where(and(eq(sessions.reminded, false)), eq(session.cancelled, false));
 
 	const sessWithin24h = sess.filter((u) => {
 		return DateTime.fromISO(u.session.start) <= DateTime.now().plus({ hours: 24 });


### PR DESCRIPTION
Hi!

We've gotten some confusion from students about getting reminder emails for cancelled session. This (should) change the reminder logic to only send reminder emails for sessions that are _not_ cancelled.